### PR TITLE
Backport etnaviv BO interface fixes

### DIFF
--- a/src/etnaviv/drm/etnaviv_bo.c
+++ b/src/etnaviv/drm/etnaviv_bo.c
@@ -86,7 +86,11 @@ static struct etna_bo *lookup_bo(void *tbl, uint32_t handle)
 		bo = etna_bo_ref(entry->data);
 
 		/* don't break the bucket if this bo was found in one */
-		list_delinit(&bo->list);
+		if (list_is_linked(&bo->list)) {
+			VG_BO_OBTAIN(bo);
+			etna_device_ref(bo->dev);
+			list_delinit(&bo->list);
+		}
 	}
 
 	return bo;

--- a/src/etnaviv/drm/etnaviv_bo.c
+++ b/src/etnaviv/drm/etnaviv_bo.c
@@ -43,6 +43,14 @@ static void set_name(struct etna_bo *bo, uint32_t name)
 	_mesa_hash_table_insert(bo->dev->name_table, &bo->name, bo);
 }
 
+int etna_bo_is_idle(struct etna_bo *bo)
+{
+	return etna_bo_cpu_prep(bo,
+			DRM_ETNA_PREP_READ |
+			DRM_ETNA_PREP_WRITE |
+			DRM_ETNA_PREP_NOSYNC) == 0;
+}
+
 /* Called under etna_drm_table_lock */
 void _etna_bo_del(struct etna_bo *bo)
 {

--- a/src/etnaviv/drm/etnaviv_bo.c
+++ b/src/etnaviv/drm/etnaviv_bo.c
@@ -51,7 +51,7 @@ int etna_bo_is_idle(struct etna_bo *bo)
 }
 
 /* Called under etna_drm_table_lock */
-void etna_bo_free(struct etna_bo *bo)
+static void _etna_bo_free(struct etna_bo *bo)
 {
 	VG_BO_FREE(bo);
 
@@ -76,6 +76,51 @@ void etna_bo_free(struct etna_bo *bo)
 	}
 
 	free(bo);
+}
+
+void etna_bo_kill_zombies(struct etna_device *dev)
+{
+	simple_mtx_assert_locked(&etna_drm_table_lock);
+
+	list_for_each_entry_safe(struct etna_bo, bo, &dev->zombie_list, list) {
+		VG_BO_OBTAIN(bo);
+		list_del(&bo->list);
+		_etna_bo_free(bo);
+	}
+}
+
+
+static void etna_bo_cleanup_zombies(struct etna_device *dev)
+{
+	simple_mtx_assert_locked(&etna_drm_table_lock);
+
+	list_for_each_entry_safe(struct etna_bo, bo, &dev->zombie_list, list) {
+		/* Stop once we reach a busy BO - all others past this point were
+		 * freed more recently so are likely also busy.
+		 */
+		if (!etna_bo_is_idle(bo))
+			break;
+
+		VG_BO_OBTAIN(bo);
+		list_del(&bo->list);
+		_etna_bo_free(bo);
+	}
+}
+
+void etna_bo_free(struct etna_bo *bo) {
+	struct etna_device *dev = bo->dev;
+
+	/* If the BO has a userspace managed address we don't free it immediately,
+	 * but keep it on a deferred destroy list until all submits with the buffer
+	 * have finished, at which point we can reuse the VMA space.
+	 */
+	if (dev->use_softpin) {
+		etna_bo_cleanup_zombies(dev);
+		VG_BO_RELEASE(bo);
+		list_addtail(&bo->list, &dev->zombie_list);
+	} else {
+		_etna_bo_free(bo);
+	}
 }
 
 /* lookup a buffer from it's handle, call w/ etna_drm_table_lock held: */

--- a/src/etnaviv/drm/etnaviv_bo.c
+++ b/src/etnaviv/drm/etnaviv_bo.c
@@ -31,7 +31,6 @@
 #include "etnaviv_drmif.h"
 
 simple_mtx_t etna_drm_table_lock = _SIMPLE_MTX_INITIALIZER_NP;
-void _etna_bo_del(struct etna_bo *bo);
 
 /* set buffer name, and add to table, call w/ etna_drm_table_lock held: */
 static void set_name(struct etna_bo *bo, uint32_t name)
@@ -52,7 +51,7 @@ int etna_bo_is_idle(struct etna_bo *bo)
 }
 
 /* Called under etna_drm_table_lock */
-void _etna_bo_del(struct etna_bo *bo)
+void etna_bo_free(struct etna_bo *bo)
 {
 	VG_BO_FREE(bo);
 
@@ -291,7 +290,7 @@ void etna_bo_del(struct etna_bo *bo)
 	if (bo->reuse && (etna_bo_cache_free(&dev->bo_cache, bo) == 0))
 		goto out;
 
-	_etna_bo_del(bo);
+	etna_bo_free(bo);
 	etna_device_del_locked(dev);
 out:
 	simple_mtx_unlock(&etna_drm_table_lock);

--- a/src/etnaviv/drm/etnaviv_bo_cache.c
+++ b/src/etnaviv/drm/etnaviv_bo_cache.c
@@ -27,8 +27,6 @@
 #include "etnaviv_priv.h"
 #include "etnaviv_drmif.h"
 
-void _etna_bo_del(struct etna_bo *bo);
-
 static void add_bucket(struct etna_bo_cache *cache, int size)
 {
 	unsigned i = cache->num_buckets;
@@ -86,7 +84,7 @@ void etna_bo_cache_cleanup(struct etna_bo_cache *cache, time_t time)
 
 			VG_BO_OBTAIN(bo);
 			list_del(&bo->list);
-			_etna_bo_del(bo);
+			etna_bo_free(bo);
 		}
 	}
 

--- a/src/etnaviv/drm/etnaviv_bo_cache.c
+++ b/src/etnaviv/drm/etnaviv_bo_cache.c
@@ -110,14 +110,6 @@ static struct etna_bo_bucket *get_bucket(struct etna_bo_cache *cache, uint32_t s
 	return NULL;
 }
 
-static int is_idle(struct etna_bo *bo)
-{
-	return etna_bo_cpu_prep(bo,
-			DRM_ETNA_PREP_READ |
-			DRM_ETNA_PREP_WRITE |
-			DRM_ETNA_PREP_NOSYNC) == 0;
-}
-
 static struct etna_bo *find_in_bucket(struct etna_bo_bucket *bucket, uint32_t flags)
 {
 	struct etna_bo *bo = NULL, *tmp;
@@ -133,7 +125,7 @@ static struct etna_bo *find_in_bucket(struct etna_bo_bucket *bucket, uint32_t fl
 			continue;
 
 		/* check if the first BO with matching flags is idle */
-		if (is_idle(bo)) {
+		if (etna_bo_is_idle(bo)) {
 			list_delinit(&bo->list);
 			goto out_unlock;
 		}

--- a/src/etnaviv/drm/etnaviv_device.c
+++ b/src/etnaviv/drm/etnaviv_device.c
@@ -51,6 +51,7 @@ struct etna_device *etna_device_new(int fd)
 	if (!ret && req.value != ~0ULL) {
 		const uint64_t _4GB = 1ull << 32;
 
+		list_inithead(&dev->zombie_list);
 		util_vma_heap_init(&dev->address_space, req.value, _4GB - req.value);
 		dev->use_softpin = 1;
 	}
@@ -84,8 +85,10 @@ static void etna_device_del_impl(struct etna_device *dev)
 {
 	etna_bo_cache_cleanup(&dev->bo_cache, 0);
 
-	if (dev->use_softpin)
+	if (dev->use_softpin) {
+		etna_bo_kill_zombies(dev);
 		util_vma_heap_finish(&dev->address_space);
+	}
 
 	_mesa_hash_table_destroy(dev->handle_table, NULL);
 	_mesa_hash_table_destroy(dev->name_table, NULL);

--- a/src/etnaviv/drm/etnaviv_drmif.h
+++ b/src/etnaviv/drm/etnaviv_drmif.h
@@ -130,6 +130,7 @@ uint32_t etna_bo_gpu_va(struct etna_bo *bo);
 void * etna_bo_map(struct etna_bo *bo);
 int etna_bo_cpu_prep(struct etna_bo *bo, uint32_t op);
 void etna_bo_cpu_fini(struct etna_bo *bo);
+int etna_bo_is_idle(struct etna_bo *bo);
 
 
 /* cmd stream functions:

--- a/src/etnaviv/drm/etnaviv_priv.h
+++ b/src/etnaviv/drm/etnaviv_priv.h
@@ -79,6 +79,7 @@ struct etna_device {
 	void *handle_table, *name_table;
 
 	struct etna_bo_cache bo_cache;
+	struct list_head zombie_list;
 
 	int use_softpin;
 	struct util_vma_heap address_space;
@@ -87,6 +88,7 @@ struct etna_device {
 };
 
 void etna_bo_free(struct etna_bo *bo);
+void etna_bo_kill_zombies(struct etna_device *dev);
 
 void etna_bo_cache_init(struct etna_bo_cache *cache);
 void etna_bo_cache_cleanup(struct etna_bo_cache *cache, time_t time);

--- a/src/etnaviv/drm/etnaviv_priv.h
+++ b/src/etnaviv/drm/etnaviv_priv.h
@@ -86,6 +86,8 @@ struct etna_device {
 	int closefd;        /* call close(fd) upon destruction */
 };
 
+void etna_bo_free(struct etna_bo *bo);
+
 void etna_bo_cache_init(struct etna_bo_cache *cache);
 void etna_bo_cache_cleanup(struct etna_bo_cache *cache, time_t time);
 struct etna_bo *etna_bo_cache_alloc(struct etna_bo_cache *cache,


### PR DESCRIPTION
This backports https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/14159 verbatim, which is required for Waydroid to work reliably on the Librem 5.

FWIW, these are already present on the lineage-18.1 branch.