### PR TITLE
android: Retrieve buffer info via CrOS API also on gbm_gralloc

### DIFF
--- a/src/egl/drivers/dri2/platform_android.c
+++ b/src/egl/drivers/dri2/platform_android.c
@@ -359,6 +359,7 @@ native_window_buffer_get_buffer_info(struct dri2_egl_display *dri2_dpy,
  */
 
 static const char cros_gralloc_module_name[] = "CrOS Gralloc";
+static const char gbm_gralloc_module_name[] = "GBM Memory Allocator";
 
 #define CROS_GRALLOC_DRM_GET_BUFFER_INFO 4
 #define CROS_GRALLOC_DRM_GET_USAGE 5
@@ -380,7 +381,8 @@ cros_get_buffer_info(struct dri2_egl_display *dri2_dpy,
 {
    struct cros_gralloc0_buffer_info info;
 
-   if (strcmp(dri2_dpy->gralloc->common.name, cros_gralloc_module_name) == 0 &&
+   if ((strcmp(dri2_dpy->gralloc->common.name, cros_gralloc_module_name) == 0 ||
+       strcmp(dri2_dpy->gralloc->common.name, gbm_gralloc_module_name) == 0) &&
        dri2_dpy->gralloc->perform &&
        dri2_dpy->gralloc->perform(dri2_dpy->gralloc,
                                   CROS_GRALLOC_DRM_GET_BUFFER_INFO,


### PR DESCRIPTION
Since gbm_gralloc still uses gralloc0, IMapper@4 isn't available there. Try to retrieve buffer info using the same perform op that CrOS uses - on gralloc_gbm versions that don't implement it it's still going to gracefully fallback into the previously used path.

This allows the modifier info to be preserved when importing buffers via EGL, fixing many troubles with multi-GPU and split display/render devices.

To be dropped once Waydroid migrates to Gralloc 4.

Requires https://github.com/waydroid/android_hardware_waydroid/pull/24 to actually make a difference.