### PR TITLE
Enable xmlconfig on Android

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -39,10 +39,10 @@ MESA_VK_LIB_SUFFIX_swrast := lvp
 
 include $(CLEAR_VARS)
 
-LOCAL_SHARED_LIBRARIES := libc libdl libdrm libm liblog libcutils libz libc++ libnativewindow libsync libhardware
+LOCAL_SHARED_LIBRARIES := libc libdl libdrm libm liblog libcutils libz libc++ libnativewindow libsync libhardware libxml2
 LOCAL_STATIC_LIBRARIES := libexpat libarect libelf
 LOCAL_HEADER_LIBRARIES := libnativebase_headers hwvulkan_headers
-MESON_GEN_PKGCONFIGS := cutils expat hardware libdrm:$(LIBDRM_VERSION) nativewindow sync zlib:1.2.11 libelf
+MESON_GEN_PKGCONFIGS := cutils expat hardware libdrm:$(LIBDRM_VERSION) nativewindow sync zlib:1.2.11 libelf libxml2
 LOCAL_CFLAGS += $(BOARD_MESA3D_CFLAGS)
 
 ifneq ($(filter swrast,$(BOARD_MESA3D_GALLIUM_DRIVERS) $(BOARD_MESA3D_VULKAN_DRIVERS)),)

--- a/android/mesa3d_cross.mk
+++ b/android/mesa3d_cross.mk
@@ -95,6 +95,7 @@ MESON_GEN_NINJA := \
 	-Dandroid-libbacktrace=disabled                                              \
 	-Dallow-kcmp=enabled                                                         \
 	-Dintel-xe-kmd=enabled                                                       \
+	-Dxmlconfig=enabled															 \
 
 MESON_BUILD := PATH=/usr/bin:/bin:/sbin:$$PATH ninja -C $(MESON_OUT_DIR)/build
 

--- a/meson.build
+++ b/meson.build
@@ -1537,7 +1537,7 @@ if dep_thread.found()
 endif
 
 with_expat = get_option('expat') \
-  .disable_auto_if(with_platform_android or with_platform_windows)
+  .disable_auto_if(with_platform_windows)
 
 if host_machine.system() == 'darwin'
   dep_expat = meson.get_compiler('c').find_library('expat', required : with_expat)
@@ -1553,8 +1553,8 @@ endif
 
 # We don't require expat on Android or Windows
 use_xmlconfig = get_option('xmlconfig') \
-  .require(not (with_platform_android or with_platform_windows),
-           error_message : 'xmlconfig not available on Android or Windows') \
+  .require(not (with_platform_windows),
+           error_message : 'xmlconfig not available on Windows') \
   .require(dep_expat.found(),
            error_message : 'requires expat') \
   .allowed()

--- a/src/util/xmlconfig.c
+++ b/src/util/xmlconfig.c
@@ -1165,6 +1165,11 @@ initOptionCache(driOptionCache *cache, const driOptionCache *info)
    }
 }
 
+#ifdef __ANDROID__
+#define SYSCONFDIR "/vendor/etc"
+#define DATADIR "/data/vendor"
+#else
+
 #ifndef SYSCONFDIR
 #define SYSCONFDIR "/etc"
 #endif
@@ -1172,6 +1177,8 @@ initOptionCache(driOptionCache *cache, const driOptionCache *info)
 #ifndef DATADIR
 #define DATADIR "/usr/share"
 #endif
+
+#endif /* __ANDROID__ */
 
 static const char *execname;
 


### PR DESCRIPTION
I don't know why Mesa still block it, but let's put this into good use. This commit includes :
- Remove Android availability check on xmlconfig
- Include libxml2 into Android.mk
- Enable xmlconfig in mesa3d_cross.mk
- On Android, /etc/drirc file will move to /vendor/etc/drirc, while /usr/share/drirc.d will move to /data/vendor/drirc.d