### PR TITLE
INTERNAL: vulkan/android: guard against unsupported AHB formats crashing

### DIFF
--- a/src/vulkan/runtime/vk_android.c
+++ b/src/vulkan/runtime/vk_android.c
@@ -805,11 +805,24 @@ get_ahb_buffer_format_properties2(
       .hal_format = desc.format,
    };
 
+   /*
+    * Guard against AHB formats that gralloc cannot handle (e.g. ETC2/EAC
+    * compressed formats on GPUs that do not support them natively through
+    * AHardwareBuffer). If the native handle is invalid or gralloc cannot
+    * identify the buffer, return an error instead of crashing.
+    */
+   if (!gr_handle.handle) {
+      mesa_loge("AHardwareBuffer has no native handle (format 0x%x)",
+                desc.format);
+      return VK_ERROR_FORMAT_NOT_SUPPORTED;
+   }
+
    struct u_gralloc_buffer_basic_info info;
    if (u_gralloc_get_buffer_basic_info(vk_android_get_ugralloc(), &gr_handle,
                                        &info) != 0) {
-      mesa_loge("Failed to get u_gralloc_buffer_basic_info");
-      return VK_ERROR_INVALID_EXTERNAL_HANDLE;
+      mesa_loge("Failed to get u_gralloc_buffer_basic_info (format 0x%x)",
+                desc.format);
+      return VK_ERROR_FORMAT_NOT_SUPPORTED;
    }
 
    switch (info.drm_fourcc) {
@@ -951,9 +964,12 @@ vk_common_GetAndroidHardwareBufferPropertiesANDROID(
       }
    }
 
-   const native_handle_t *handle = AHardwareBuffer_getNativeHandle(buffer);
-   assert(handle && handle->numFds > 0);
-   pProperties->allocationSize = lseek(handle->data[0], 0, SEEK_END);
+    const native_handle_t *handle = AHardwareBuffer_getNativeHandle(buffer);
+    if (!handle || handle->numFds <= 0) {
+       mesa_loge("AHardwareBuffer has invalid native handle");
+       return VK_ERROR_FORMAT_NOT_SUPPORTED;
+    }
+    pProperties->allocationSize = lseek(handle->data[0], 0, SEEK_END);
 
    VkMemoryFdPropertiesKHR fd_props = {
       .sType = VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR,

--- a/src/vulkan/runtime/vk_android.c
+++ b/src/vulkan/runtime/vk_android.c
@@ -964,15 +964,15 @@ vk_common_GetAndroidHardwareBufferPropertiesANDROID(
       }
    }
 
-    const native_handle_t *handle = AHardwareBuffer_getNativeHandle(buffer);
-    if (!handle || handle->numFds <= 0) {
-       AHardwareBuffer_Desc desc;
-       AHardwareBuffer_describe(buffer, &desc);
-       mesa_loge("AHardwareBuffer has invalid native handle (format 0x%x)",
-                 desc.format);
-       return VK_ERROR_FORMAT_NOT_SUPPORTED;
-    }
-    pProperties->allocationSize = lseek(handle->data[0], 0, SEEK_END);
+   const native_handle_t *handle = AHardwareBuffer_getNativeHandle(buffer);
+   if (!handle || handle->numFds <= 0) {
+      AHardwareBuffer_Desc desc;
+      AHardwareBuffer_describe(buffer, &desc);
+      mesa_loge("AHardwareBuffer has invalid native handle (format 0x%x)",
+                desc.format);
+      return VK_ERROR_FORMAT_NOT_SUPPORTED;
+   }
+   pProperties->allocationSize = lseek(handle->data[0], 0, SEEK_END);
 
    VkMemoryFdPropertiesKHR fd_props = {
       .sType = VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR,

--- a/src/vulkan/runtime/vk_android.c
+++ b/src/vulkan/runtime/vk_android.c
@@ -966,7 +966,10 @@ vk_common_GetAndroidHardwareBufferPropertiesANDROID(
 
     const native_handle_t *handle = AHardwareBuffer_getNativeHandle(buffer);
     if (!handle || handle->numFds <= 0) {
-       mesa_loge("AHardwareBuffer has invalid native handle");
+       AHardwareBuffer_Desc desc;
+       AHardwareBuffer_describe(buffer, &desc);
+       mesa_loge("AHardwareBuffer has invalid native handle (format 0x%x)",
+                 desc.format);
        return VK_ERROR_FORMAT_NOT_SUPPORTED;
     }
     pProperties->allocationSize = lseek(handle->data[0], 0, SEEK_END);


### PR DESCRIPTION
### Problem

`vk_ahb_format_to_image_format()` returns `VK_FORMAT_UNDEFINED` for AHB formats not in the equivalence table (such as ETC2/EAC compressed formats). When this happens, `get_ahb_buffer_format_properties2()` falls into the external format path and calls `AHardwareBuffer_getNativeHandle()`, which can return a null handle when gralloc cannot process the format. This leads to a SIGABRT.

There is a secondary crash site in `vk_common_GetAndroidHardwareBufferPropertiesANDROID` where the native handle is used with an assert that aborts on null.

### Changes

Added defensive null-check guards at both `AHardwareBuffer_getNativeHandle` call sites:

1. In `get_ahb_buffer_format_properties2()`: check if the native handle is null before passing it to `u_gralloc_get_buffer_basic_info()`. Return `VK_ERROR_FORMAT_NOT_SUPPORTED`.

2. In `vk_common_GetAndroidHardwareBufferPropertiesANDROID`: replace the assert with a proper null check. Return `VK_ERROR_FORMAT_NOT_SUPPORTED`.

Both error paths log the AHB format code via `mesa_loge` to aid debugging.

### Context

This crash is triggered in Waydroid when ARM64 Unity games attempt to use ETC2 compressed textures through AHardwareBuffer on Intel GPUs (Mesa ANV). Originally, a companion Vulkan layer workaround was proposed in waydroid/android_hardware_waydroid#69, but addressing the root cause here in Mesa ensures that unsupported AHB formats fail gracefully instead of crashing the application.

### Testing

Tested on Intel UHD 620 with Waydroid LineageOS 20. ARM64 Unity games that previously crashed with SIGABRT on launch now receive `VK_ERROR_FORMAT_NOT_SUPPORTED` and successfully fall back to uncompressed textures.

Closes: https://github.com/waydroid/waydroid/issues/702
Closes: https://github.com/waydroid/waydroid/issues/2187

Signed-off-by: Uzair Mughal <contact@uzair.is-a.dev>
